### PR TITLE
feat: update run param for sql/script plugin

### DIFF
--- a/build/register.xml.tpl
+++ b/build/register.xml.tpl
@@ -16,6 +16,8 @@
 
     <!-- 4.系统参数 - 描述运行本插件包需要的系统参数 -->
     <systemParameters>
+        <systemParameter name="SALTSTACK_SQL_S3" scopeType="global" defaultValue="S3"/>
+        <systemParameter name="SALTSTACK_SQL_USER_PARAM" scopeType="global" defaultValue="USER_PARAM"/>
         <systemParameter name="SALTSTACK_SCRIPT_LOCAL" scopeType="global" defaultValue="LOCAL"/>
         <systemParameter name="SALTSTACK_SCRIPT_S3" scopeType="global" defaultValue="S3"/>
         <systemParameter name="SALTSTACK_SCRIPT_USER_PARAM" scopeType="global" defaultValue="USER_PARAM"/>
@@ -273,6 +275,26 @@
         <plugin name="mysql-script" targetPackage="" targetEntity="" registerName="" targetEntityFilterRule="">
             <interface action="run" path="/saltstack/v1/mysql-script/run" filterRule="">
                 <inputParameters>
+                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_SQL_S3">sourceType</parameter>
+                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">endpoint</parameter>
+                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
+                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">sql_files</parameter>
+                    <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_SEED" >seed</parameter>
+                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">host</parameter>
+                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">userName</parameter>
+                    <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="entity" mappingEntityExpression="">password</parameter>
+                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">port</parameter>
+                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">databaseName</parameter>
+                </inputParameters>
+                <outputParameters>
+                    <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
+                    <parameter datatype="string" sensitiveData="N" mappingType="context">errorCode</parameter>
+                    <parameter datatype="string" sensitiveData="N" mappingType="context">errorMessage</parameter>
+                </outputParameters>
+            </interface>
+            <interface action="run-user-param" path="/saltstack/v1/mysql-script/run" filterRule="">
+                <inputParameters>
+                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_SQL_USER_PARAM">sourceType</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">endpoint</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">sql_files</parameter>

--- a/build/register.xml.tpl
+++ b/build/register.xml.tpl
@@ -16,8 +16,6 @@
 
     <!-- 4.系统参数 - 描述运行本插件包需要的系统参数 -->
     <systemParameters>
-        <systemParameter name="SALTSTACK_SQL_S3" scopeType="global" defaultValue="S3"/>
-        <systemParameter name="SALTSTACK_SQL_USER_PARAM" scopeType="global" defaultValue="USER_PARAM"/>
         <systemParameter name="SALTSTACK_SCRIPT_LOCAL" scopeType="global" defaultValue="LOCAL"/>
         <systemParameter name="SALTSTACK_SCRIPT_S3" scopeType="global" defaultValue="S3"/>
         <systemParameter name="SALTSTACK_SCRIPT_USER_PARAM" scopeType="global" defaultValue="USER_PARAM"/>
@@ -275,26 +273,6 @@
         <plugin name="mysql-script" targetPackage="" targetEntity="" registerName="" targetEntityFilterRule="">
             <interface action="run" path="/saltstack/v1/mysql-script/run" filterRule="">
                 <inputParameters>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_SQL_S3">sourceType</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">endpoint</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">sql_files</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_SEED" >seed</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">host</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">userName</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="entity" mappingEntityExpression="">password</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">port</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">databaseName</parameter>
-                </inputParameters>
-                <outputParameters>
-                    <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
-                    <parameter datatype="string" sensitiveData="N" mappingType="context">errorCode</parameter>
-                    <parameter datatype="string" sensitiveData="N" mappingType="context">errorMessage</parameter>
-                </outputParameters>
-            </interface>
-            <interface action="run-user-param" path="/saltstack/v1/mysql-script/run" filterRule="">
-                <inputParameters>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_SQL_USER_PARAM">sourceType</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">endpoint</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">sql_files</parameter>
@@ -461,8 +439,6 @@
                     <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_SEED" >seed</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="entity" mappingEntityExpression="">appPublicKey</parameter>
                     <parameter datatype="string" required="N" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="SYSTEM_PRIVATE_KEY" >sysPrivateKey</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_APP_BACKUP_PATH">appBackUpPath</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_APP_BACKUP_ENABLED">appBackUpEnabled</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="constant">logFileTrade</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="constant">logFileTrace</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="constant">logFileMetric</parameter>
@@ -476,33 +452,6 @@
                     <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">logFileTrace</parameter>
                     <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">logFileMetric</parameter>
                     <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">logFileKeyword</parameter>
-                    <parameter datatype="string" sensitiveData="N" mappingType="context">errorCode</parameter>
-                    <parameter datatype="string" sensitiveData="N" mappingType="context">errorMessage</parameter>
-                </outputParameters>
-            </interface>
-            <interface action="rollback" path="/saltstack/v1/apply-deployment/rollback" filterRule="">
-                <inputParameters>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">target</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">userName</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">endpoint</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">confFiles</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">destinationPath</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">variableList</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">stopScript</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">startScript</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">args</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_SEED" >seed</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_APP_BACKUP_PATH">appBackUpPath</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_APP_BACKUP_ENABLED">appBackUpEnabled</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_APP_BACKUP_EXCLUDE">excludePath</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="entity" mappingEntityExpression="">appPublicKey</parameter>
-                    <parameter datatype="string" required="N" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="SYSTEM_PRIVATE_KEY" >sysPrivateKey</parameter>
-                </inputParameters>
-                <outputParameters>
-                    <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">guid</parameter>
-                    <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">s3PkgPath</parameter>
-                    <parameter datatype="string" sensitiveData="N" mappingType="entity" mappingEntityExpression="">fileDetail</parameter>
                     <parameter datatype="string" sensitiveData="N" mappingType="context">errorCode</parameter>
                     <parameter datatype="string" sensitiveData="N" mappingType="context">errorMessage</parameter>
                 </outputParameters>

--- a/build/register.xml.tpl
+++ b/build/register.xml.tpl
@@ -88,7 +88,6 @@
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">confFiles</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">endpoint</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">variableList</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_VARIBLE_PREFIX">encryptVariblePrefix</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="FILE_VARIBLE_PREFIX">fileReplacePrefix</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_SEED" >seed</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="entity" mappingEntityExpression="">appPublicKey</parameter>
@@ -401,7 +400,6 @@
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">variableList</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">startScript</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">args</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_VARIBLE_PREFIX">encryptVariblePrefix</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_SEED" >seed</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="entity" mappingEntityExpression="">appPublicKey</parameter>
                     <parameter datatype="string" required="N" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="SYSTEM_PRIVATE_KEY" >sysPrivateKey</parameter>
@@ -472,7 +470,6 @@
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">stopScript</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="N" mappingType="entity" mappingEntityExpression="">startScript</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="entity" mappingEntityExpression="">args</parameter>
-                    <parameter datatype="string" required="Y" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_VARIBLE_PREFIX">encryptVariblePrefix</parameter>
                     <parameter datatype="string" required="Y" sensitiveData="Y" mappingType="system_variable" mappingSystemVariableName="ENCRYPT_SEED" >seed</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_APP_BACKUP_PATH">appBackUpPath</parameter>
                     <parameter datatype="string" required="N" sensitiveData="N" mappingType="system_variable" mappingSystemVariableName="SALTSTACK_APP_BACKUP_ENABLED">appBackUpEnabled</parameter>

--- a/plugins/apply_deployment.go
+++ b/plugins/apply_deployment.go
@@ -46,13 +46,13 @@ type ApplyNewDeploymentInput struct {
 	StartScriptPath  string `json:"startScript,omitempty"`
 	// AccessKey    string `json:"accessKey,omitempty"`
 	// SecretKey    string `json:"secretKey,omitempty"`
-	EncryptVariblePrefix string `json:"encryptVariblePrefix,omitempty"`
-	Seed                 string `json:"seed,omitempty"`
-	AppPublicKey         string `json:"appPublicKey,omitempty"`
-	SysPrivateKey        string `json:"sysPrivateKey,omitempty"`
-	Password             string `json:"password,omitempty"`
-	RwDir                string `json:"rwDir,omitempty"`
-	RwFile               string `json:"rwFile,omitempty"`
+	// EncryptVariblePrefix string `json:"encryptVariblePrefix,omitempty"`
+	Seed          string `json:"seed,omitempty"`
+	AppPublicKey  string `json:"appPublicKey,omitempty"`
+	SysPrivateKey string `json:"sysPrivateKey,omitempty"`
+	Password      string `json:"password,omitempty"`
+	RwDir         string `json:"rwDir,omitempty"`
+	RwFile        string `json:"rwFile,omitempty"`
 
 	LogFileTrade   string `json:"logFileTrade,omitempty"`
 	LogFileTrace   string `json:"logFileTrace,omitempty"`
@@ -195,14 +195,14 @@ func (action *ApplyNewDeploymentAction) applyNewDeployment(input ApplyNewDeploym
 		variableReplaceRequest := VariableReplaceInputs{
 			Inputs: []VariableReplaceInput{
 				VariableReplaceInput{
-					Guid:                 input.Guid,
-					EndPoint:             input.EndPoint,
-					FilePath:             input.VariableFilePath,
-					VariableList:         input.VariableList,
-					EncryptVariblePrefix: input.EncryptVariblePrefix,
-					Seed:                 input.Seed,
-					AppPublicKey:         input.AppPublicKey,
-					SysPrivateKey:        input.SysPrivateKey,
+					Guid:         input.Guid,
+					EndPoint:     input.EndPoint,
+					FilePath:     input.VariableFilePath,
+					VariableList: input.VariableList,
+					// EncryptVariblePrefix: input.EncryptVariblePrefix,
+					Seed:          input.Seed,
+					AppPublicKey:  input.AppPublicKey,
+					SysPrivateKey: input.SysPrivateKey,
 				},
 			},
 		}
@@ -333,19 +333,19 @@ type ApplyUpdateDeploymentInput struct {
 	StopScriptPath   string `json:"stopScript,omitempty"`
 	StartScriptPath  string `json:"startScript,omitempty"`
 
-	EncryptVariblePrefix string `json:"encryptVariblePrefix,omitempty"`
-	Seed                 string `json:"seed,omitempty"`
-	AppPublicKey         string `json:"appPublicKey,omitempty"`
-	SysPrivateKey        string `json:"sysPrivateKey,omitempty"`
+	// EncryptVariblePrefix string `json:"encryptVariblePrefix,omitempty"`
+	Seed          string `json:"seed,omitempty"`
+	AppPublicKey  string `json:"appPublicKey,omitempty"`
+	SysPrivateKey string `json:"sysPrivateKey,omitempty"`
 
 	LogFileTrade   string `json:"logFileTrade,omitempty"`
 	LogFileTrace   string `json:"logFileTrace,omitempty"`
 	LogFileMetric  string `json:"logFileMetric,omitempty"`
 	LogFileKeyword string `json:"logFileKeyword,omitempty"`
 
-	AppBackUpEnabled     string `json:"appBackUpEnabled,omitempty"`
-	AppBackUpPath        string `json:"appBackUpPath,omitempty"`
-	ExcludePath          string `json:"excludePath,omitempty"`
+	AppBackUpEnabled string `json:"appBackUpEnabled,omitempty"`
+	AppBackUpPath    string `json:"appBackUpPath,omitempty"`
+	ExcludePath      string `json:"excludePath,omitempty"`
 }
 
 type ApplyUpdateDeploymentOutputs struct {
@@ -490,14 +490,14 @@ func (action *ApplyUpdateDeploymentAction) applyUpdateDeployment(input ApplyUpda
 		variableReplaceRequest := VariableReplaceInputs{
 			Inputs: []VariableReplaceInput{
 				VariableReplaceInput{
-					Guid:                 input.Guid,
-					EndPoint:             input.EndPoint,
-					FilePath:             input.VariableFilePath,
-					VariableList:         input.VariableList,
-					EncryptVariblePrefix: input.EncryptVariblePrefix,
-					Seed:                 input.Seed,
-					AppPublicKey:         input.AppPublicKey,
-					SysPrivateKey:        input.SysPrivateKey,
+					Guid:         input.Guid,
+					EndPoint:     input.EndPoint,
+					FilePath:     input.VariableFilePath,
+					VariableList: input.VariableList,
+					// EncryptVariblePrefix: input.EncryptVariblePrefix,
+					Seed:          input.Seed,
+					AppPublicKey:  input.AppPublicKey,
+					SysPrivateKey: input.SysPrivateKey,
 				},
 			},
 		}

--- a/plugins/mysql_scripts.go
+++ b/plugins/mysql_scripts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"strings"
 
 	"github.com/WeBankPartners/wecube-plugins-saltstack/common/log"
@@ -182,15 +183,12 @@ func (action *RunMysqlScriptAction) runMysqlScript(input *RunMysqlScriptInput) (
 	// add user input sql support
 	var fileNameList []string
 	if input.SourceType == SOURCE_TYPE_USER_PARAM {
-		sqlFile, err := getTempFile()
-		if err != nil {
+		sqlFile := path.Join(UPLOADS3FILE_DIR, fmt.Sprintf("%s-%s.sql", input.Guid, getRandString()))
+		if err = writeStringToFile(input.Sql, sqlFile); err != nil {
 			return output, err
 		}
 		defer os.Remove(sqlFile)
 
-		if err = writeStringToFile(input.Sql, sqlFile); err != nil {
-			return output, err
-		}
 		fileNameList = append(fileNameList, sqlFile)
 	} else {
 		for _, v := range splitWithCustomFlag(input.EndPoint) {

--- a/plugins/mysql_scripts.go
+++ b/plugins/mysql_scripts.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"github.com/WeBankPartners/wecube-plugins-saltstack/common/log"
@@ -171,13 +170,17 @@ func (action *RunMysqlScriptAction) runMysqlScript(input *RunMysqlScriptInput) (
 
 	// add user input sql support
 	if input.Sql != "" {
-		sqlFile := path.Join(UPLOADS3FILE_DIR, fmt.Sprintf("%s-%s.sql", input.Guid, getRandString()))
-		if err = writeStringToFile(input.Sql, sqlFile); err != nil {
+		tmpFile, err := os.CreateTemp(UPLOADS3FILE_DIR, fmt.Sprintf("%s-*.sql", input.Guid))
+		if err != nil {
 			return output, err
 		}
-		defer os.Remove(sqlFile)
+		defer os.Remove(tmpFile.Name())
 
-		fileNameList = append(fileNameList, sqlFile)
+		if err = writeStringToFile(input.Sql, tmpFile.Name()); err != nil {
+			return output, err
+		}
+
+		fileNameList = append(fileNameList, tmpFile.Name())
 	}
 
 	for _, v := range splitWithCustomFlag(input.EndPoint) {

--- a/plugins/scripts.go
+++ b/plugins/scripts.go
@@ -146,7 +146,7 @@ func saveFileToSaltMasterBaseDir(fileName string) (string, error) {
 	return fullPath, err
 }
 
-func executeS3Script(fileName string, target string, runAs string, execArg string, language string) (string, error) {
+func executeS3Script(fileName string, target string, runAs string, execArg string, cwd string, language string) (string, error) {
 	request := SaltApiRequest{}
 	request.Client = "local"
 	request.TargetType = "ipcidr"
@@ -161,6 +161,11 @@ func executeS3Script(fileName string, target string, runAs string, execArg strin
 	if len(runAs) > 0 {
 		request.Args = append(request.Args, "runas="+runAs)
 	}
+
+	if len(cwd) > 0 {
+		request.Args = append(request.Args, "cwd="+cwd)
+	}
+
 	if !SaltResetEnv {
 		request.Args = append(request.Args, "reset_system_locale=False")
 	}
@@ -369,7 +374,7 @@ func runScript(scriptPath string, input RunScriptInput, language string) (string
 			break
 		}
 	case END_POINT_TYPE_S3, END_POINT_TYPE_USER_PARAM:
-		result, err = executeS3Script(filepath.Base(scriptPath), input.Target, input.RunAs, input.ExecArg, language)
+		result, err = executeS3Script(filepath.Base(scriptPath), input.Target, input.RunAs, input.ExecArg, input.WorkDir, language)
 		//os.Remove(scriptPath)
 		if err != nil {
 			return "", getRunRemoteScriptError(language, input.Target, result, err)

--- a/plugins/user.go
+++ b/plugins/user.go
@@ -170,7 +170,7 @@ func (action *AddUserAction) Do(input interface{}) (interface{}, error) {
 			execArg += " --rwFile '" + input.RwFile + "'"
 		}
 
-		result, err := executeS3Script("user_manage.sh", input.Target, runAs, execArg, action.Language)
+		result, err := executeS3Script("user_manage.sh", input.Target, runAs, execArg, "", action.Language)
 		if err != nil {
 			log.Logger.Error("Add user action", log.Error(err))
 			output.Result.Code = RESULT_CODE_ERROR
@@ -300,7 +300,7 @@ func (action *DeleteUserAction) Do(input interface{}) (interface{}, error) {
 		}
 
 		execArg := fmt.Sprintf("--action remove --user %s ", input.UserName)
-		result, err := executeS3Script("user_manage.sh", input.Target, runAs, execArg, action.Language)
+		result, err := executeS3Script("user_manage.sh", input.Target, runAs, execArg, "", action.Language)
 		if err != nil {
 			output.Result.Code = RESULT_CODE_ERROR
 			output.Result.Message = err.Error()
@@ -445,7 +445,7 @@ func (action *ChangeUserPasswordAction) Do(input interface{}) (interface{}, erro
 
 		execArg += " --password '" + password + "'"
 
-		result, err := executeS3Script("user_manage.sh", input.Target, runAs, execArg, action.Language)
+		result, err := executeS3Script("user_manage.sh", input.Target, runAs, execArg, "", action.Language)
 		if err != nil {
 			output.Result.Code = RESULT_CODE_ERROR
 			output.Result.Message = err.Error()

--- a/plugins/variable_replace.go
+++ b/plugins/variable_replace.go
@@ -63,11 +63,11 @@ type VariableReplaceInput struct {
 	// SecretKey    string `json:"secretKey,omitempty"`
 
 	//support aomp password encrypt
-	EncryptVariblePrefix string `json:"encryptVariblePrefix,omitempty"`
-	Seed                 string `json:"seed,omitempty"`
-	AppPublicKey         string `json:"appPublicKey,omitempty"`
-	SysPrivateKey        string `json:"sysPrivateKey,omitempty"`
-	FileReplacePrefix    string `json:"fileReplacePrefix,omitempty"`
+	// EncryptVariblePrefix string `json:"encryptVariblePrefix,omitempty"`
+	Seed              string `json:"seed,omitempty"`
+	AppPublicKey      string `json:"appPublicKey,omitempty"`
+	SysPrivateKey     string `json:"sysPrivateKey,omitempty"`
+	FileReplacePrefix string `json:"fileReplacePrefix,omitempty"`
 }
 
 // VariableReplaceOutputs .


### PR DESCRIPTION
5、salt数据库脚本执行增加个用户输入sql参数
6、salt应用部署的差异化变量替换加密前缀参数去掉，统一走系统参数注入
9、saltstack 远程脚本执行，workDir应该作用于s3和userParam，在目标路径下运行